### PR TITLE
BUG: fixed error attempting to read too many frames

### DIFF
--- a/itkpocus/itkpocus/butterfly.py
+++ b/itkpocus/itkpocus/butterfly.py
@@ -55,7 +55,7 @@ def ffprobe_count_frames(filename):
             streamsbytype[d["stream"]["@codec_type"].lower()] = d["stream"]
 
         return streamsbytype
-    except AttibuteError as e:
+    except AttributeError as e:
         print(e)
         return {}
     except:
@@ -79,7 +79,11 @@ def vread_workaround(fp, ffprobe_count_frames_dict=None):
         Video array in F,H,W,RGB format
     '''
     ffprobe_count_frames_dict = ffprobe_count_frames_dict if ffprobe_count_frames_dict is not None else ffprobe_count_frames(fp)
-    return vread(fp, outputdict={'-vframes' : ffprobe_count_frames_dict['video']['@nb_read_frames']})
+    
+    # in rare cases, butterfly-iq will encode duplicate frames or whatnot that cause the output frames from ffmpeg to be lower
+    # than that recorded by ffprobe as it resamples for a constant frame rate
+    # vsync 0 forces ffmpeg to not resample
+    return vread(fp, outputdict={'-vsync' : '0', '-vframes' : ffprobe_count_frames_dict['video']['@nb_read_frames']})
 
 def _calc_spacing(npvid):
     '''

--- a/itkpocus/tests/test_butterfly.py
+++ b/itkpocus/tests/test_butterfly.py
@@ -26,5 +26,13 @@ class TestButterfly(unittest.TestCase):
         self.assertAlmostEqual(crop[0,1], 1048)
         print(crop)
     
+    def test_vread_workaround(self):
+        f = './tests/data/butterfly-vsync.mp4'
+        x = itkpocus.butterfly.vread_workaround(f)
+        self.assertAlmostEqual(x.shape[0], 761)
+        self.assertAlmostEqual(x.shape[1], 1080)
+        self.assertAlmostEqual(x.shape[2], 776)
+        self.assertAlmostEqual(x.shape[3], 3)
+    
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Added the -vsync 0 option to ffmpeg.  This prevents it
from attempting to resample the output video according to a
framerate.  The rare bug was causing some butterfly videos
with odd frames to error out as the code attempted to read more
frames than ffmpeg was outputing.