### PR TITLE
Sonoque crop fix

### DIFF
--- a/itkpocus/itkpocus/sonoque.py
+++ b/itkpocus/itkpocus/sonoque.py
@@ -176,7 +176,9 @@ def load_and_preprocess_video(fp, version=None):
     npfirst = npvid[0,:,:]
     spacing = _find_spacing(npfirst)
     spacing = [spacing, spacing, itkpocus.util.get_framerate(vidmeta)]
-    crop = _find_crop(npfirst)
+
+    npmean = np.mean(npvid, axis=0)
+    crop = _find_crop(npmean)
     
     npvid_rgb = itkpocus.util.crop(npvid_rgb, crop, rgb=True)
     npvid = itkpocus.util.crop(npvid, crop)

--- a/itkpocus/tests/test_sonoque.py
+++ b/itkpocus/tests/test_sonoque.py
@@ -25,6 +25,12 @@ class TestSonoque(unittest.TestCase):
         self.assertAlmostEqual(crop[0,0], 72)
         self.assertAlmostEqual(crop[0,1], 1382)
         print(crop)
+
+    def test_mean_crop(self):
+        img, _ = itkpocus.sonoque.load_and_preprocess_video('./tests/data/sonoque-mean-crop.MOV')
+        img_size = img.GetLargestPossibleRegion().GetSize()
+        self.assertGreaterEqual(img_size[0], 900)
+        self.assertGreaterEqual(img_size[1], 1200)
     
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Similar to #33 , except with sonoque. Switch to taking the mean of the ultrasound video to decide where to crop to. Previously we just used the first frame, which would lead to cropping issues if the first frame was mostly dark in the center