### PR TITLE
Fixed pickling error due to spacing type

### DIFF
--- a/itkpocus/itkpocus/interson.py
+++ b/itkpocus/itkpocus/interson.py
@@ -40,14 +40,9 @@ def _find_spacing_and_crop(npimg):
     midrow = npimg.shape[0]/2.0
     rowsum = np.sum(npimg[:,leftbound:rightbound+1,0], axis=1)
     zerorow = np.argwhere(rowsum == 0)
-    
-    if len(zerorow) == 0: # fills the whole image vertically
-        topbound=0
-        bottombound=npimg.shape[0]-1
-    else:
-        topbound = np.max(zerorow[zerorow < midrow])
-        bottombound = np.min(zerorow[midrow < zerorow])
-    
+   
+    topbound = np.max(np.append(zerorow[zerorow < midrow], 0))
+    bottombound = np.min(np.append(zerorow[midrow < zerorow],  npimg.shape[0]-1))   
     
     # interson ruler on left side and has text above it
     colsum2 = np.sum(npimg[topbound:(bottombound+1),:,0], axis=0)

--- a/itkpocus/itkpocus/sonivate.py
+++ b/itkpocus/itkpocus/sonivate.py
@@ -30,7 +30,7 @@ def preprocess_image(img_raw, version=None, probe_type='linear'):
     img = itk.image_from_array(npimg)
     
     img.SetSpacing([img_raw.GetSpacing()[0], img_raw.GetSpacing()[1]])
-    return img, { 'spacing' : img.GetSpacing(), 'crop' : crop }
+    return img, { 'spacing' : [ img.GetSpacing()[0], img.GetSpacing()[1] ], 'crop' : crop }
 
 def preprocess_video(img_raw, version=None, probe_type='linear' ):
     '''
@@ -60,7 +60,7 @@ def preprocess_video(img_raw, version=None, probe_type='linear' ):
     img = itk.image_from_array(npimg)
     img.SetSpacing([0.0776016, 0.0776016, 1/24.0])
     
-    return img, { 'spacing' : img.GetSpacing(), 'crop' : crop }
+    return img, { 'spacing' : [ img.GetSpacing()[0], img.GetSpacing()[1], img.GetSpacing()[2] ], 'crop' : crop }
 
 def load_and_preprocess_image(fp, version=None, probe_type='linear'):
     '''


### PR DESCRIPTION
Fixes a `Cannot pickle 'SwigPyObject'` error due to the return of the ITK spacing type.